### PR TITLE
Fix compatibility issues with some saml implementations

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -3,6 +3,7 @@ from binascii import hexlify
 import copy
 from hashlib import sha1
 import logging
+import zlib
 
 import requests
 
@@ -444,7 +445,10 @@ class Entity(HTTPBase):
                 if binding == BINDING_HTTP_REDIRECT:
                     xmlstr = decode_base64_and_inflate(txt)
                 elif binding == BINDING_HTTP_POST:
-                    xmlstr = base64.b64decode(txt)
+                    try:
+                        xmlstr = decode_base64_and_inflate(txt)
+                    except zlib.error:
+                        xmlstr = base64.b64decode(txt)
                 elif binding == BINDING_SOAP:
                     func = getattr(soap, f"parse_soap_enveloped_saml_{msgtype}")
                     xmlstr = func(txt)


### PR DESCRIPTION
### Description

##### The feature or problem addressed by this PR

[RSA test suite](https://sptest.iamshowcase.com/instructions#) and other integrations seem to fail with pysaml2 because they use deflate on post bindings

##### What your changes do and why you chose this solution

Tries to deflate post binding data, just in case.   Should be perfectly safe since a valid zip encoding has no overlap with valid utfs/xml encoding.